### PR TITLE
tools/build-image.sh: use --owner/--group with tar instead of sudo

### DIFF
--- a/images/microOS/config.xml
+++ b/images/microOS/config.xml
@@ -149,6 +149,7 @@
         <package name="etcd"/>
         <package name="etcdctl"/>
         <archive name="aquarium.tar.gz"/>
+        <archive name="root.tar.gz"/>
     </packages>
 
     <packages type="image" profiles="Vagrant-x86_64">

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -146,17 +146,19 @@ make dist
 tmpdir=$(mktemp -d)
 pushd ${tmpdir}
 tar --strip-components=1 -xzf ${rootdir}/aquarium*.tar.gz
-sudo cp -r ${imgdir}/microOS/root/* ./
-tar -czf ${build}/aquarium.tar.gz .
+tar --owner root --group root -czf ${build}/aquarium.tar.gz .
 popd
 rm -rf ${tmpdir}
 
-tmpdir=$(mktemp -d)
-pushd ${tmpdir}
-sudo cp -r ${imgdir}/microOS/aquarium_root/* ./
-tar -czf ${build}/aquarium_user.tar.gz .
+# Extra files needed in system root
+pushd ${imgdir}/microOS/root
+tar --owner root --group root -czf ${build}/root.tar.gz .
 popd
-rm -rf ${tmpdir}
+
+# Extra files needed in system root for live image
+pushd ${imgdir}/microOS/aquarium_root
+tar --owner root --group root -czf ${build}/aquarium_user.tar.gz .
+popd
 
 
 cp ${imgdir}/microOS/config.{sh,xml} ${build}/


### PR DESCRIPTION
Using `tar --owner root --group root` means the tarballs are created with files owned by root:root, so when kiwi extracts them, they have the correct uid:gid.  This means we don't need to copy the files around first.  I've also split the root tarball creation off from the aquarium dist tarball, to make it a bit clearer what each tarball is for.

Signed-off-by: Tim Serong <tserong@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [issue id or URL on https://github.com/aquarist-labs/aquarium/issues, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The component is the short name of a major module or subsystem, something 
like "tools", "gravel", "glass", "doc", etc.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://github.com/aquarist-labs/aquarium/blob/main/CONTRIBUTING.md

-->

## Checklist
- [ ] References issues, create if required
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test tumbleweed`
- `jenkins run tumbleweed`
- `jenkins test leap`
- `jenkins run leap`

</details>
